### PR TITLE
Switch EKS add-ons to pod identity

### DIFF
--- a/project05/terraform/eks_cluster.tf
+++ b/project05/terraform/eks_cluster.tf
@@ -169,16 +169,3 @@ resource "aws_security_group" "worker_default" {
         "karpenter.sh/discovery" = local.cluster_name
     })
 }
-
-# OIDC Provider 설정
-data "tls_certificate" "this" {
-    url = aws_eks_cluster.this.identity[0].oidc[0].issuer
-}
-
-resource "aws_iam_openid_connect_provider" "this" {
-    client_id_list  = [ "sts.amazonaws.com" ]
-    thumbprint_list = [ data.tls_certificate.this.certificates[0].sha1_fingerprint ]
-    url             = aws_eks_cluster.this.identity[0].oidc[0].issuer
-
-    depends_on      = [ aws_eks_cluster.this ]
-}


### PR DESCRIPTION
## Summary
- replace the IRSA-based IAM roles for core add-ons with EKS Pod Identity roles and associations
- enable the eks-pod-identity-agent add-on and remove the unused OIDC provider resource

## Testing
- terraform fmt *(fails: terraform not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d76339971c83288ccbb465ec4a87c7