### PR TITLE
Replace aws-auth ConfigMap with EKS access entries

### DIFF
--- a/project05/terraform/eks_access_entries.tf
+++ b/project05/terraform/eks_access_entries.tf
@@ -1,0 +1,54 @@
+# EKS Access Entry - Terraform 관리자 역할
+resource "aws_eks_access_entry" "terraform_admin" {
+    cluster_name  = aws_eks_cluster.this.name
+    principal_arn = data.aws_iam_role.terraform_admin.arn
+}
+
+resource "aws_eks_access_policy_association" "terraform_admin_cluster_admin" {
+    cluster_name  = aws_eks_cluster.this.name
+    principal_arn = data.aws_iam_role.terraform_admin.arn
+    policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+
+    access_scope {
+        type = "cluster"
+    }
+
+    depends_on = [aws_eks_access_entry.terraform_admin]
+}
+
+# EKS Access Entry - EKS 관리자 역할
+resource "aws_eks_access_entry" "eks_admin" {
+    cluster_name  = aws_eks_cluster.this.name
+    principal_arn = data.aws_iam_role.eks_admin.arn
+}
+
+resource "aws_eks_access_policy_association" "eks_admin_cluster_admin" {
+    cluster_name  = aws_eks_cluster.this.name
+    principal_arn = data.aws_iam_role.eks_admin.arn
+    policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+
+    access_scope {
+        type = "cluster"
+    }
+
+    depends_on = [aws_eks_access_entry.eks_admin]
+}
+
+# EKS Access Entry - 기본 노드 그룹 역할
+resource "aws_eks_access_entry" "default_node_group" {
+    cluster_name  = aws_eks_cluster.this.name
+    principal_arn = aws_iam_role.default_node_group.arn
+    type          = "EC2_LINUX"
+}
+
+resource "aws_eks_access_policy_association" "default_node_group" {
+    cluster_name  = aws_eks_cluster.this.name
+    principal_arn = aws_iam_role.default_node_group.arn
+    policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSNodeAccessPolicy"
+
+    access_scope {
+        type = "cluster"
+    }
+
+    depends_on = [aws_eks_access_entry.default_node_group]
+}

--- a/project05/terraform/provider.tf
+++ b/project05/terraform/provider.tf
@@ -13,8 +13,7 @@ provider "aws" {
 }
 
 # Kubernetes Provider 설정
-# EKS 클러스터의 kubernetes API 서버와 통신하기 위한 설정
-# aws-auth ConfigMap 생성 및 관리에 사용됨
+# EKS 클러스터의 Kubernetes API 서버와 통신하기 위한 설정
 provider "kubernetes" {
     host                   = aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority[0].data)


### PR DESCRIPTION
## Summary
- remove the aws-auth ConfigMap management from the Terraform configuration
- add EKS access entries and policy associations for admin and node IAM roles
- update the node group dependency to wait for the access policy association

## Testing
- not run (terraform not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d76339971c83288ccbb465ec4a87c7