### PR TITLE
Fix EKS access policy and pod identity trust configuration

### DIFF
--- a/project05/terraform/eks_access_entries.tf
+++ b/project05/terraform/eks_access_entries.tf
@@ -46,7 +46,7 @@ resource "aws_eks_access_entry" "default_node_group" {
 resource "aws_eks_access_policy_association" "default_node_group" {
     cluster_name  = aws_eks_cluster.this.name
     principal_arn = aws_iam_role.default_node_group.arn
-    policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSNodeAccessPolicy"
+    policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSNodePolicy"
 
     access_scope {
         type = "cluster"
@@ -66,7 +66,7 @@ resource "aws_eks_access_entry" "karpenter_node" {
 resource "aws_eks_access_policy_association" "karpenter_node" {
     cluster_name  = aws_eks_cluster.this.name
     principal_arn = aws_iam_role.karpenter_node.arn
-    policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSNodeAccessPolicy"
+    policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSNodePolicy"
 
     access_scope {
         type = "cluster"

--- a/project05/terraform/eks_addon_poi.tf
+++ b/project05/terraform/eks_addon_poi.tf
@@ -12,7 +12,10 @@ data "aws_iam_policy_document" "pod_identity_assume_role" {
     ])
 
     statement {
-        actions = ["sts:AssumeRole"]
+        actions = [
+            "sts:AssumeRole",
+            "sts:TagSession",
+        ]
         effect  = "Allow"
 
         principals {

--- a/project05/terraform/eks_karpenter.tf
+++ b/project05/terraform/eks_karpenter.tf
@@ -1,6 +1,6 @@
 # Karpenter 노드 인스턴스 프로파일
 resource "aws_iam_instance_profile" "karpenter" {
-    name = "karpenter-node-profile"
+    name = "${local.project_name}-karpenter-node-profile"
     role = aws_iam_role.karpenter_node.name
 }
 

--- a/project05/terraform/eks_karpenter_iam.tf
+++ b/project05/terraform/eks_karpenter_iam.tf
@@ -39,7 +39,10 @@ resource "aws_iam_role_policy_attachment" "karpenter_node_ssm" {
 # Karpenter 컨트롤러 IAM 역할
 data "aws_iam_policy_document" "karpenter_pod_identity_assume_role" {
     statement {
-        actions = ["sts:AssumeRole"]
+        actions = [
+            "sts:AssumeRole",
+            "sts:TagSession",
+        ]
         effect  = "Allow"
 
         principals {


### PR DESCRIPTION
## Summary
- update node IAM access associations to use the correct AmazonEKSNodePolicy ARN
- allow pod identity roles to call sts:TagSession alongside sts:AssumeRole
- rename the Karpenter instance profile to include the project prefix to avoid name collisions

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d78e8ffc2c83288e31591c4be5c9b3