### PR TITLE
Restore standard node access entries and trust policies

### DIFF
--- a/project05/terraform/eks_access_entries.tf
+++ b/project05/terraform/eks_access_entries.tf
@@ -39,14 +39,13 @@ resource "aws_eks_access_policy_association" "eks_admin_cluster_admin" {
 resource "aws_eks_access_entry" "default_node_group" {
     cluster_name  = aws_eks_cluster.this.name
     principal_arn = aws_iam_role.default_node_group.arn
-    # type          = "EC2_LINUX"
     type          = "STANDARD"
 }
 
 resource "aws_eks_access_policy_association" "default_node_group" {
     cluster_name  = aws_eks_cluster.this.name
     principal_arn = aws_iam_role.default_node_group.arn
-    policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSNodeAccessPolicy"
+    policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSNodePolicy"
 
     access_scope {
         type = "cluster"
@@ -59,14 +58,13 @@ resource "aws_eks_access_policy_association" "default_node_group" {
 resource "aws_eks_access_entry" "karpenter_node" {
     cluster_name  = aws_eks_cluster.this.name
     principal_arn = aws_iam_role.karpenter_node.arn
-    # type          = "EC2_LINUX"
     type          = "STANDARD"
 }
 
 resource "aws_eks_access_policy_association" "karpenter_node" {
     cluster_name  = aws_eks_cluster.this.name
     principal_arn = aws_iam_role.karpenter_node.arn
-    policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSNodeAccessPolicy"
+    policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSNodePolicy"
 
     access_scope {
         type = "cluster"


### PR DESCRIPTION
## Summary
- revert the managed and Karpenter node access entries to STANDARD so cluster access policies can attach
- point node access entries at the AmazonEKSNodePolicy ARN that exists in EKS
- restore the previous pod identity trust policies used by the addons and Karpenter controller
- keep the existing Karpenter instance profile name expected by the Helm release

## Testing
- not run (terraform is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d78e8ffc2c83288e31591c4be5c9b3