### PR TITLE
Configure EKS add-ons to use Pod Identity

### DIFF
--- a/project05/terraform/eks_addon.tf
+++ b/project05/terraform/eks_addon.tf
@@ -1,181 +1,119 @@
-# # kube-proxy 애드온
-# resource "aws_eks_addon" "kube_proxy" {
-#     cluster_name                = aws_eks_cluster.this.name
-#     addon_name                  = "kube-proxy"
-#     resolve_conflicts_on_create = "OVERWRITE"
-#     resolve_conflicts_on_update = "PRESERVE"
+# kube-proxy 애드온
+resource "aws_eks_addon" "kube_proxy" {
+  cluster_name                = aws_eks_cluster.this.name
+  addon_name                  = "kube-proxy"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
 
-#     depends_on = [aws_eks_cluster.this]
-# }
+  depends_on = [aws_eks_cluster.this]
+}
 
-# # CoreDNS 애드온
-# resource "aws_eks_addon" "coredns" {
-#     cluster_name                = aws_eks_cluster.this.name
-#     addon_name                  = "coredns"
-#     resolve_conflicts_on_create = "OVERWRITE"
-#     resolve_conflicts_on_update = "PRESERVE"
+# CoreDNS 애드온
+resource "aws_eks_addon" "coredns" {
+  cluster_name                = aws_eks_cluster.this.name
+  addon_name                  = "coredns"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
 
-#     depends_on = [aws_eks_cluster.this]
-# }
+  depends_on = [aws_eks_cluster.this]
+}
 
-# # VPC CNI 애드온
-# resource "aws_eks_addon" "vpc_cni" {
-#     cluster_name                = aws_eks_cluster.this.name
-#     addon_name                  = "vpc-cni"
-#     service_account_role_arn    = aws_iam_role.vpc_cni.arn
-#     resolve_conflicts_on_create = "OVERWRITE"
-#     resolve_conflicts_on_update = "PRESERVE"
+# EKS Pod Identity Agent 애드온
+resource "aws_eks_addon" "pod_identity" {
+  cluster_name                = aws_eks_cluster.this.name
+  addon_name                  = "eks-pod-identity-agent"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
 
-#     depends_on = [
-#         aws_eks_cluster.this,
-#         aws_iam_openid_connect_provider.this,
-#         aws_eks_addon.kube_proxy
-#     ]
-# }
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_eks_addon.coredns,
+  ]
+}
 
-# # EBS CSI 드라이버 애드온
-# resource "aws_eks_addon" "ebs_csi" {
-#     cluster_name                = aws_eks_cluster.this.name
-#     addon_name                  = "aws-ebs-csi-driver"
-#     service_account_role_arn    = aws_iam_role.ebs_csi.arn
-#     resolve_conflicts_on_create = "OVERWRITE"
-#     resolve_conflicts_on_update = "PRESERVE"
+# VPC CNI 애드온
+resource "aws_eks_addon" "vpc_cni" {
+  cluster_name                = aws_eks_cluster.this.name
+  addon_name                  = "vpc-cni"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
 
-#     depends_on = [
-#         aws_eks_cluster.this,
-#         aws_iam_openid_connect_provider.this,
-#         aws_eks_addon.coredns
-#     ]
-# }
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_eks_addon.kube_proxy,
+  ]
+}
 
-# # # EKS Pod Identity Agent 애드온
-# # - IRSA의 새로운 대안(2023년 말 출시)으로 OIDC 불필요, 성능 향상
-# # - 현재는 IRSA가 안정적이므로 보류
-# # resource "aws_eks_addon" "pod_identity" {
-# #     cluster_name                = aws_eks_cluster.this.name
-# #     addon_name                  = "eks-pod-identity-agent"
-# #     resolve_conflicts_on_create = "OVERWRITE"
-# #     resolve_conflicts_on_update = "PRESERVE"
+# EBS CSI 드라이버 애드온
+resource "aws_eks_addon" "ebs_csi" {
+  cluster_name                = aws_eks_cluster.this.name
+  addon_name                  = "aws-ebs-csi-driver"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
 
-# #     depends_on = [
-# #         aws_eks_cluster.this,
-# #         aws_eks_addon.coredns
-# #     ]
-# # }
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_eks_addon.coredns,
+  ]
+}
 
-# # Metrics Server  애드온
-# resource "aws_eks_addon" "metrics_server" {
-#     cluster_name                = aws_eks_cluster.this.name
-#     addon_name                  = "metrics-server"
-#     resolve_conflicts_on_create = "OVERWRITE"
-#     resolve_conflicts_on_update = "PRESERVE"
+# Metrics Server 애드온
+resource "aws_eks_addon" "metrics_server" {
+  cluster_name                = aws_eks_cluster.this.name
+  addon_name                  = "metrics-server"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
 
-#     depends_on = [aws_eks_cluster.this]
-# }
+  depends_on = [aws_eks_cluster.this]
+}
 
-# # AWS Load Balancer Controller
-# # - https://docs.aws.amazon.com/ko_kr/eks/latest/userguide/lbc-helm.html
-# resource "helm_release" "aws_load_balancer_controller" {
-#     name       = "aws-load-balancer-controller"
-#     repository = "https://aws.github.io/eks-charts"
-#     chart      = "aws-load-balancer-controller"
-#     namespace  = "kube-system"
+# AWS Load Balancer Controller
+# - https://docs.aws.amazon.com/ko_kr/eks/latest/userguide/lbc-helm.html
+resource "helm_release" "aws_load_balancer_controller" {
+  name       = "aws-load-balancer-controller"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  namespace  = "kube-system"
 
-#     set {
-#         name  = "region"
-#         value = "ap-northeast-2"
-#     }
+  set {
+    name  = "region"
+    value = data.aws_region.current.name
+  }
 
-#     set {
-#         name  = "vpcId"
-#         value = aws_vpc.main.id
-#     }
+  set {
+    name  = "vpcId"
+    value = aws_vpc.main.id
+  }
 
-#     set {
-#         name  = "clusterName"
-#         value = aws_eks_cluster.this.name
-#     }
+  set {
+    name  = "clusterName"
+    value = aws_eks_cluster.this.name
+  }
 
-#     set {
-#         name  = "serviceAccount.create"
-#         value = "false"
-#     }
+  set {
+    name  = "serviceAccount.create"
+    value = "false"
+  }
 
-#     set {
-#         name  = "serviceAccount.name"
-#         value = "aws-load-balancer-controller"
-#     }
+  set {
+    name  = "serviceAccount.name"
+    value = kubernetes_service_account.aws_load_balancer_controller.metadata[0].name
+  }
 
+  depends_on = [
+    aws_iam_policy.aws_load_balancer_controller,
+    aws_iam_role.aws_load_balancer_controller,
+    aws_iam_role_policy_attachment.aws_load_balancer_controller,
+    kubernetes_service_account.aws_load_balancer_controller,
+    aws_eks_pod_identity_association.aws_load_balancer_controller,
+  ]
+}
 
-#     set {
-#         name  = "serviceAccount.name"
-#         value = "aws-load-balancer-controller"
-#     }
-
-#     depends_on = [
-#         aws_iam_policy.aws_load_balancer_controller,
-#         aws_iam_role.aws_load_balancer_controller,
-#         aws_iam_role_policy_attachment.aws_load_balancer_controller,
-#         kubernetes_service_account.aws_load_balancer_controller
-#     ]
-# }
-
-# # StorageClass 생성
-# resource "kubernetes_manifest" "storageclass" {
-#     manifest = yamldecode(file("${path.module}/manifests/storageclass.yaml"))
-#     depends_on = [
-#         aws_eks_cluster.this,
-#         aws_eks_addon.ebs_csi
-#     ]
-# }
-
-# # # Mountpoint for Amazon S3 CSI 드라이버
-# # resource "aws_eks_addon" "s3_csi" {
-# #     cluster_name                = aws_eks_cluster.this.name
-# #     addon_name                  = "aws-mountpoint-s3-csi-driver"
-# #     service_account_role_arn    = aws_iam_role.s3_csi.arn
-# #     resolve_conflicts_on_create = "OVERWRITE"
-# #     resolve_conflicts_on_update = "PRESERVE"
-# #     configuration_values = jsonencode({
-# #         node = {
-# #             tolerateAllTaints = true
-# #         }
-# #     })
-
-# #     depends_on = [
-# #         aws_eks_cluster.this,
-# #         aws_iam_openid_connect_provider.this,
-# #         aws_eks_addon.coredns,
-# #         aws_s3_bucket.app_data
-# #     ]
-# # }
-
-# # # 노드 모니터링 에이전트
-# # resource "aws_eks_addon" "node_monitoring" {
-# #     cluster_name                = aws_eks_cluster.this.name
-# #     addon_name                  = "eks-node-monitoring-agent"
-# #     resolve_conflicts_on_create = "OVERWRITE"
-# #     resolve_conflicts_on_update = "PRESERVE"
-
-# #     depends_on = [aws_eks_cluster.this]
-# # }
-
-# # # AWS Network Flow Monitor Agent
-# # resource "aws_eks_addon" "network_flow" {
-# #     cluster_name                = aws_eks_cluster.this.name
-# #     addon_name                  = "aws-network-flow-monitoring-agent"
-# #     resolve_conflicts_on_create = "OVERWRITE"
-# #     resolve_conflicts_on_update = "PRESERVE"
-
-# #     depends_on = [aws_eks_cluster.this]
-# # }
-
-# # # AWS Private CA Connector for Kubernetes
-# # resource "aws_eks_addon" "private_ca" {
-# #     cluster_name                = aws_eks_cluster.this.name
-# #     addon_name                  = "aws-privateca-connector-for-kubernetes"
-# #     resolve_conflicts_on_create = "OVERWRITE"
-# #     resolve_conflicts_on_update = "PRESERVE"
-
-# #     depends_on = [aws_eks_cluster.this]
-# # }
+# StorageClass 생성
+resource "kubernetes_manifest" "storageclass" {
+  manifest = yamldecode(file("${path.module}/manifests/storageclass.yaml"))
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_eks_addon.ebs_csi,
+  ]
+}

--- a/project05/terraform/eks_addon_poi.tf
+++ b/project05/terraform/eks_addon_poi.tf
@@ -1,120 +1,145 @@
-# resource "aws_iam_policy" "aws_load_balancer_controller" {
-#     name = "${local.project_name}-aws-load-balancer-controller-policy"
-#     policy = file("${path.module}/manifests/aws-load-balancer-controller-policy.json")
-# }
+resource "aws_iam_policy" "aws_load_balancer_controller" {
+  name   = "${local.project_name}-aws-load-balancer-controller-policy"
+  policy = file("${path.module}/manifests/aws-load-balancer-controller-policy.json")
+}
 
-# # EKS Pod Identity용 AssumeRole 정책
-# data "aws_iam_policy_document" "pod_identity_assume_role" {
-#     for_each = toset([
-#         "ebs_csi",
-#         "vpc_cni",
-#         "aws_load_balancer_controller",
-#     ])
+# EKS Pod Identity용 AssumeRole 정책
+# VPC CNI, EBS CSI, AWS Load Balancer Controller의 Pod Identity 역할에 공통으로 사용
+# eks-pod-identity-agent 애드온에서 발급하는 토큰을 신뢰하도록 구성
+# SourceArn 조건으로 동일 클러스터의 Pod Identity Association에서만 호출 허용
+# SourceAccount 조건으로 현재 계정에서만 허용하도록 제한
+# 리소스는 for_each를 사용하여 각 서비스 별로 생성
+# - ebs_csi: aws-ebs-csi-driver 컨트롤러
+# - vpc_cni: aws-node 데몬셋
+# - aws_load_balancer_controller: ALB 컨트롤러 헬름 릴리스
+# https://docs.aws.amazon.com/eks/latest/userguide/pod-identity.html
+# https://docs.aws.amazon.com/ko_kr/eks/latest/userguide/pod-id-assume-role.html
+# Pod Identity를 사용할 경우 OIDC 공급자 없이도 STS를 사용할 수 있음
+# 하지만 다른 구성 요소에서 OIDC를 사용할 수 있으므로 기존 설정은 유지함
+# 이 문서는 Pod Identity Agent 애드온이 설치된 이후에만 유효
+# 따라서 association 리소스에서 애드온에 대한 depends_on을 지정함
+# assume role 정책에는 TagSession 권한도 포함하여 AWS Load Balancer Controller의 태깅 요구 사항 충족
+# session tagging을 사용하면 리소스에 컨트롤러가 태그를 추가할 수 있음
+# Terraform에서는 toset을 활용하여 고정된 세 가지 항목에 대해 반복 생성
+# 필요 시 향후 다른 애드온도 쉽게 추가 가능
+# 역할 이름은 프로젝트 이름 기반으로 고유하게 생성
+# 정책 문서는 aws_iam_policy_document 데이터 소스를 사용하여 JSON 생성
+# 각 역할은 해당 서비스가 필요로 하는 AWS 관리형 정책을 연결
+# Pod Identity association 리소스는 namespace와 service account를 지정하여 EKS와 연결
 
-#     statement {
-#         actions = [
-#             "sts:AssumeRole",
-#             "sts:TagSession",
-#         ]
-#         effect  = "Allow"
+# Pod Identity용 AssumeRole 정책 문서
+# (위 설명 주석은 유지, 아래 리소스는 실제 정의)
+data "aws_iam_policy_document" "pod_identity_assume_role" {
+  for_each = toset([
+    "ebs_csi",
+    "vpc_cni",
+    "aws_load_balancer_controller",
+  ])
 
-#         principals {
-#             identifiers = ["pods.eks.amazonaws.com"]
-#             type        = "Service"
-#         }
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+    effect = "Allow"
 
-#         condition {
-#             test     = "ArnLike"
-#             variable = "aws:SourceArn"
-#             values = [
-#                 "arn:aws:eks:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:podidentityassociation/${aws_eks_cluster.this.name}/*"
-#             ]
-#         }
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
 
-#         condition {
-#             test     = "StringEquals"
-#             variable = "aws:SourceAccount"
-#             values   = [data.aws_caller_identity.current.account_id]
-#         }
-#     }
-# }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values = [
+        "arn:aws:eks:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:podidentityassociation/${aws_eks_cluster.this.name}/*",
+      ]
+    }
 
-# # EBS CSI Controller를 위한 Pod Identity 역할
-# resource "aws_iam_role" "ebs_csi" {
-#     name               = "${local.project_name}-ebs-csi-role"
-#     assume_role_policy = data.aws_iam_policy_document.pod_identity_assume_role["ebs_csi"].json
-# }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
 
-# resource "aws_iam_role_policy_attachment" "ebs_csi" {
-#     role       = aws_iam_role.ebs_csi.name
-#     policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-# }
+# EBS CSI Controller를 위한 Pod Identity 역할
+resource "aws_iam_role" "ebs_csi" {
+  name               = "${local.project_name}-ebs-csi-role"
+  assume_role_policy = data.aws_iam_policy_document.pod_identity_assume_role["ebs_csi"].json
+}
 
-# resource "aws_eks_pod_identity_association" "ebs_csi" {
-#     cluster_name    = aws_eks_cluster.this.name
-#     namespace       = "kube-system"
-#     service_account = "ebs-csi-controller-sa"
-#     role_arn        = aws_iam_role.ebs_csi.arn
+resource "aws_iam_role_policy_attachment" "ebs_csi" {
+  role       = aws_iam_role.ebs_csi.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
 
-#     depends_on = [
-#         aws_eks_addon.pod_identity,
-#         aws_eks_addon.ebs_csi,
-#     ]
-# }
+resource "aws_eks_pod_identity_association" "ebs_csi" {
+  cluster_name    = aws_eks_cluster.this.name
+  namespace       = "kube-system"
+  service_account = "ebs-csi-controller-sa"
+  role_arn        = aws_iam_role.ebs_csi.arn
 
-# # VPC CNI를 위한 Pod Identity 역할
-# resource "aws_iam_role" "vpc_cni" {
-#     name               = "${local.project_name}-vpc-cni-role"
-#     assume_role_policy = data.aws_iam_policy_document.pod_identity_assume_role["vpc_cni"].json
-# }
+  depends_on = [
+    aws_eks_addon.pod_identity,
+    aws_eks_addon.ebs_csi,
+  ]
+}
 
-# resource "aws_iam_role_policy_attachment" "vpc_cni" {
-#     role       = aws_iam_role.vpc_cni.name
-#     policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-# }
+# VPC CNI를 위한 Pod Identity 역할
+resource "aws_iam_role" "vpc_cni" {
+  name               = "${local.project_name}-vpc-cni-role"
+  assume_role_policy = data.aws_iam_policy_document.pod_identity_assume_role["vpc_cni"].json
+}
 
-# resource "aws_eks_pod_identity_association" "vpc_cni" {
-#     cluster_name    = aws_eks_cluster.this.name
-#     namespace       = "kube-system"
-#     service_account = "aws-node"
-#     role_arn        = aws_iam_role.vpc_cni.arn
+resource "aws_iam_role_policy_attachment" "vpc_cni" {
+  role       = aws_iam_role.vpc_cni.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
 
-#     depends_on = [
-#         aws_eks_addon.pod_identity,
-#         aws_eks_addon.vpc_cni,
-#     ]
-# }
+resource "aws_eks_pod_identity_association" "vpc_cni" {
+  cluster_name    = aws_eks_cluster.this.name
+  namespace       = "kube-system"
+  service_account = "aws-node"
+  role_arn        = aws_iam_role.vpc_cni.arn
 
-# # AWS Load Balancer Controller를 위한 Pod Identity 역할
-# resource "aws_iam_role" "aws_load_balancer_controller" {
-#     name               = "${local.project_name}-aws-load-balancer-controller"
-#     assume_role_policy = data.aws_iam_policy_document.pod_identity_assume_role["aws_load_balancer_controller"].json
-# }
+  depends_on = [
+    aws_eks_addon.pod_identity,
+    aws_eks_addon.vpc_cni,
+  ]
+}
 
-# resource "aws_iam_role_policy_attachment" "aws_load_balancer_controller" {
-#     policy_arn = aws_iam_policy.aws_load_balancer_controller.arn
-#     role       = aws_iam_role.aws_load_balancer_controller.name
-# }
+# AWS Load Balancer Controller를 위한 Pod Identity 역할
+resource "aws_iam_role" "aws_load_balancer_controller" {
+  name               = "${local.project_name}-aws-load-balancer-controller"
+  assume_role_policy = data.aws_iam_policy_document.pod_identity_assume_role["aws_load_balancer_controller"].json
+}
 
-# resource "kubernetes_service_account" "aws_load_balancer_controller" {
-#     metadata {
-#         name      = "aws-load-balancer-controller"
-#         namespace = "kube-system"
-#         labels = {
-#             "app.kubernetes.io/name"      = "aws-load-balancer-controller"
-#             "app.kubernetes.io/component" = "controller"
-#         }
-#     }
-# }
+resource "aws_iam_role_policy_attachment" "aws_load_balancer_controller" {
+  policy_arn = aws_iam_policy.aws_load_balancer_controller.arn
+  role       = aws_iam_role.aws_load_balancer_controller.name
+}
 
-# resource "aws_eks_pod_identity_association" "aws_load_balancer_controller" {
-#     cluster_name    = aws_eks_cluster.this.name
-#     namespace       = "kube-system"
-#     service_account = kubernetes_service_account.aws_load_balancer_controller.metadata[0].name
-#     role_arn        = aws_iam_role.aws_load_balancer_controller.arn
+resource "kubernetes_service_account" "aws_load_balancer_controller" {
+  metadata {
+    name      = "aws-load-balancer-controller"
+    namespace = "kube-system"
+    labels = {
+      "app.kubernetes.io/name"      = "aws-load-balancer-controller"
+      "app.kubernetes.io/component" = "controller"
+    }
+  }
+}
 
-#     depends_on = [
-#         aws_eks_addon.pod_identity,
-#         kubernetes_service_account.aws_load_balancer_controller,
-#     ]
-# }
+resource "aws_eks_pod_identity_association" "aws_load_balancer_controller" {
+  cluster_name    = aws_eks_cluster.this.name
+  namespace       = "kube-system"
+  service_account = kubernetes_service_account.aws_load_balancer_controller.metadata[0].name
+  role_arn        = aws_iam_role.aws_load_balancer_controller.arn
+
+  depends_on = [
+    aws_eks_addon.pod_identity,
+    kubernetes_service_account.aws_load_balancer_controller,
+  ]
+}


### PR DESCRIPTION
## Summary
- enable the core EKS add-ons and install the Pod Identity agent for the project05 cluster
- create IAM roles and Pod Identity associations for VPC CNI, EBS CSI, and the AWS Load Balancer Controller
- update the AWS Load Balancer Controller Helm release to rely on the managed service account and Pod Identity association

## Testing
- not run (terraform not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7a01d94b48328a5564d0a311b7c7c